### PR TITLE
Use Test\Descriptor instead of TestCase when splitting by test

### DIFF
--- a/src/SplitTestsByGroups.php
+++ b/src/SplitTestsByGroups.php
@@ -83,7 +83,7 @@ class SplitTestsByGroupsTask extends TestsSplitter implements TaskInterface
         $this->printTaskInfo("Processing ".count($tests)." tests");
         // splitting tests by groups
         foreach ($tests as $test) {
-            $groups[($i % $this->numGroups) + 1][] = \Codeception\TestCase::getTestFullName($test);
+            $groups[($i % $this->numGroups) + 1][] = \Codeception\Test\Descriptor::getTestFullName($test);
             $i++;
         }
 


### PR DESCRIPTION
I was following [this guide](http://codeception.com/docs/12-ParallelExecution) and decided to split my tests using the second, `taskSplitTestsByGroups `, method.

This produced the following exception:

```
$ vendor/bin/robo parallel:split-tests
 [Codeception\Task\SplitTestsByGroupsTask] Processing 14 tests
PHP Fatal error:  Class 'Codeception\TestCase' not found in /<path>/tests/vendor/codeception/robo-paracept/src/SplitTestsByGroups.php on line 86
ERROR: Class 'Codeception\TestCase' not found
in /<path>/tests/vendor/codeception/robo-paracept/src/SplitTestsByGroups.php:86
```

Codeception version: 2.2.4
robo: 0.7.2
robo-paracept version: dev-master

I believe this change is all that is needed. It does work absolutely fine in my case.