### PR TITLE
Remove TaskIO trait from merge reports, as BaseTask already uses it.

### DIFF
--- a/src/MergeReports.php
+++ b/src/MergeReports.php
@@ -1,7 +1,6 @@
 <?php
 namespace Codeception\Task;
 
-use Robo\Common\TaskIO;
 use Robo\Contract\TaskInterface;
 use Robo\Exception\TaskException;
 use Robo\Task\BaseTask;
@@ -21,8 +20,6 @@ trait MergeReports
 
 class MergeXmlReportsTask extends BaseTask implements TaskInterface
 {
-    use TaskIO;
-
     protected $src = [];
     protected $dst;
     protected $summarizeTime = true;
@@ -130,8 +127,6 @@ class MergeXmlReportsTask extends BaseTask implements TaskInterface
  */
 class MergeHTMLReportsTask extends BaseTask implements TaskInterface
 {
-    use TaskIO;
-
     protected $src = [];
     protected $dst;
     protected $countSuccess = 0;

--- a/src/SplitTestsByGroups.php
+++ b/src/SplitTestsByGroups.php
@@ -1,7 +1,6 @@
 <?php
 namespace Codeception\Task;
 
-use Robo\Common\TaskIO;
 use Robo\Contract\TaskInterface;
 use Robo\Exception\TaskException;
 use Robo\Task\BaseTask;
@@ -23,8 +22,6 @@ trait SplitTestsByGroups
 
 abstract class TestsSplitter extends BaseTask
 {
-    use TaskIO;
-
     protected $numGroups;
     protected $projectRoot = '.';
     protected $testsFrom = 'tests';


### PR DESCRIPTION
I don't really know much about this project, but @Dorkstars mentioned in gitter.im that this was causing a problem, so here's what I think the fix is :smile:

From gitter.im:

> @Dorkstars Hello, how can i fix error:
> ERROR: Robo\Task\BaseTask and Robo\Common\TaskIO define the same property ($config) in the composition of Codeception\Task\MergeHTMLReportsTask. This might be incompatible, to improve maintainability consider using accessor methods in traits instead. Class was composed

Looks like BaseTask already uses the TaskIO trait, so no need for the reports to also use that trait - it's inherited from BaseTask now.