### PR TITLE
Remove unnecessary use statements

### DIFF
--- a/src/MergeReports.php
+++ b/src/MergeReports.php
@@ -21,8 +21,6 @@ trait MergeReports
 
 class MergeXmlReportsTask extends BaseTask implements TaskInterface
 {
-    use TaskIO;
-
     protected $src = [];
     protected $dst;
     protected $summarizeTime = true;
@@ -130,8 +128,6 @@ class MergeXmlReportsTask extends BaseTask implements TaskInterface
  */
 class MergeHTMLReportsTask extends BaseTask implements TaskInterface
 {
-    use TaskIO;
-
     protected $src = [];
     protected $dst;
     protected $countSuccess = 0;

--- a/src/SplitTestsByGroups.php
+++ b/src/SplitTestsByGroups.php
@@ -23,8 +23,6 @@ trait SplitTestsByGroups
 
 abstract class TestsSplitter extends BaseTask
 {
-    use TaskIO;
-
     protected $numGroups;
     protected $projectRoot = '.';
     protected $testsFrom = 'tests';


### PR DESCRIPTION
With PHP errors set to Strict, you get the following error

ERROR: Robo\Task\BaseTask and Robo\Common\TaskIO define the same property ($config) in the composition of Codeception\Task\TestsSplitter. This might be incompatible, to improve maintainability consider using accessor methods in traits instead.

since TestsSplitter extends BaseTask. Same applies to MergeXmlReportsTask and MergeHtmlReportsTask.

Removing traits from child classed solved the issue.

Tests are broken at the moment by the way, however I didn't fix that.