### PR TITLE
new feature: filter by codeception group

### DIFF
--- a/src/SplitTestsByGroups.php
+++ b/src/SplitTestsByGroups.php
@@ -1,6 +1,10 @@
 <?php
 namespace Codeception\Task;
 
+use Codeception\Lib\GroupManager;
+use Codeception\Test\Cept;
+use Codeception\Test\Cest;
+use Codeception\Util\Annotation;
 use Robo\Common\TaskIO;
 use Robo\Contract\TaskInterface;
 use Robo\Exception\TaskException;
@@ -69,6 +73,30 @@ abstract class TestsSplitter extends BaseTask
  */
 class SplitTestsByGroupsTask extends TestsSplitter implements TaskInterface
 {
+    private $filterGroup = '';
+
+    /**
+     * Matches any line that this a line comment beginning with "//".
+     */
+    const REGEXP_LINE_COMMENT = '~\/\/(.*?)$~m';
+
+    /**
+     * Matches any line that is part of a block comment beginning with "/*".
+     */
+    const REGEXP_BLOCK_COMMENT = '~\/*\*(.*?)\*\/~ms';
+
+    /**
+     * Sets a filter group. Only tests belonging to this specific Codeception group will be executed.
+     *
+     * @param $group string name of the Codeception group to be filtered
+     * @return $this
+     */
+    public function filterByGroup($group)
+    {
+        $this->filterGroup = $group;
+        return $this;
+    }
+
     public function run()
     {
         if (!class_exists('\Codeception\Test\Loader')) {
@@ -84,16 +112,82 @@ class SplitTestsByGroupsTask extends TestsSplitter implements TaskInterface
         $this->printTaskInfo("Processing ".count($tests)." tests");
         // splitting tests by groups
         foreach ($tests as $test) {
-            $groups[($i % $this->numGroups) + 1][] = \Codeception\Test\Descriptor::getTestFullName($test);
-            $i++;
+            if (empty($this->filterGroup) || $this->matchesToFilterGroup($test)) {
+                $fullname = str_replace('\\', '/', \Codeception\Test\Descriptor::getTestFullName($test));
+                $groups[($i % $this->numGroups) + 1][] = $fullname;
+                $i++;
+            }
         }
+
+        $this->printTaskInfo(
+            sprintf(
+                "%s test%s match%s the criterias. They will be divided in up to %s groups.",
+                $i,
+                ($i == 1 ? '' : 's'),
+                ($i == 1 ? 'es' : ''),
+                $this->numGroups
+            )
+        );
+
 
         // saving group files
         foreach ($groups as $i => $tests) {
             $filename = $this->saveTo . $i;
-            $this->printTaskInfo("Writing $filename");
+            $this->printTaskInfo(sprintf("Writing %s (includes %s tests)", $filename, count($tests)));
             file_put_contents($filename, implode("\n", $tests));
         }
+    }
+
+    /**
+     * Determines if the test is part of the filter group.
+     *
+     * @param $test mixed Any kind of codeption test. Cest or Cept
+     * @return bool Returns "true" if the test is part of the filter group, otherwise "false".
+     */
+    protected function matchesToFilterGroup($test)
+    {
+        $isFilterGroupMatched = false;
+
+        if (false === empty($this->filterGroup)) {
+            $phpunitGroups = [];
+
+            if ($test instanceof Cept) {
+                $phpunitGroups = Annotation::fetchAllFromComment(
+                    'group',
+                    $this->findCommentsInCept($test->getSourceCode())
+                );
+            } elseif ($test instanceof Cest) {
+                $groupManager = new GroupManager(array());
+                $phpunitGroups = $groupManager->groupsForTest($test);
+            }
+
+            $isFilterGroupMatched = in_array($this->filterGroup, $phpunitGroups);
+        }
+
+        return $isFilterGroupMatched;
+    }
+
+    /**
+     * Returns all comments that could be found in the code of a Cept test
+     *
+     * @param $code string File content of a Cept file
+     * @return string Comments as a string
+     */
+    protected function findCommentsInCept($code)
+    {
+        $matches = [];
+        $comments = '';
+        $hasLineComment = preg_match_all(self::REGEXP_LINE_COMMENT, $code, $matches);
+        if ($hasLineComment && isset($matches[1])) {
+            foreach ($matches[1] as $line) {
+                $comments .= $line . PHP_EOL;
+            }
+        }
+        $hasBlockComment = preg_match(self::REGEXP_BLOCK_COMMENT, $code, $matches);
+        if ($hasBlockComment && isset($matches[1])) {
+            $comments .= $matches[1] . PHP_EOL;
+        }
+        return $comments;
     }
 }
 


### PR DESCRIPTION
Hi,
when I executed my codeception tests in parallel it is a common scenario that I only what to execute a specific codeception group (f.e. "smoke", "regression"). I added this feature.
I know it's a bit confusing because the word "group" is also used in the context of how paracept divides the tests to be executed into group files.

Example how to use it in console:
````
robo parallel:split-tests -g smoke
````

Example how to use it in ``Robofile``

````
class RoboFile extends \Robo\Tasks
{
    use \Codeception\Task\SplitTestsByGroups;

    public function parallelSplitTests($opts = ['processes|p' => self::PROCESSES_DEFAULT, 'group|g' => ''])
    {
        $testSplitter = $this->taskSplitTestsByGroups($opts['processes']);
        if (false === empty($opts['group'])) {
            $testSplitter->filterByGroup($opts['group']);
        }

        return $testSplitter
            ->groupsTo($this->groupsTo)
            ->run();
    }
}
````

