### PR TITLE
Fix DOM query in CountSummary method in MergeHTMLReportsTask

### DIFF
--- a/src/MergeReports.php
+++ b/src/MergeReports.php
@@ -225,7 +225,7 @@ class MergeHTMLReportsTask extends BaseTask implements TaskInterface, MergeRepor
      * @param $dstFile \DOMDocument - destination file
      */
     private function countSummary($dstFile){
-        $tests = (new \DOMXPath($dstFile))->query("//table//tr[contains(@class,'scenarioRow')]");
+        $tests = (new \DOMXPath($dstFile))->query("//table/tr[contains(@class,'scenarioRow')]");
         foreach($tests as $test){
             $class = str_replace('scenarioRow ', '', $test->getAttribute('class'));
             switch($class){


### PR DESCRIPTION
The query used in DOMXPath fails on large HTML files. And it is due to the additional slash on the query. So it is removed from the countSummary method.