### PR TITLE
Force SplitTestFilesByGroupsTask to sort files by name

### DIFF
--- a/src/SplitTestsByGroups.php
+++ b/src/SplitTestsByGroups.php
@@ -135,7 +135,8 @@ class SplitTestFilesByGroupsTask extends TestsSplitter implements TaskInterface
             ->name('*.feature')
             ->path($this->testsFrom)
             ->in($this->projectRoot ? $this->projectRoot : getcwd())
-            ->exclude($this->excludePath);
+            ->exclude($this->excludePath)
+            ->sortByName();
 
         $i = 0;
         $groups = [];


### PR DESCRIPTION
We are running our tests in CircleCi in 2 containers.
We split our tests in different groups and run half of the groups in one container and the other half in the other.
For some reason (that I still haven't figured out), `Finder` was returning the files in a different order in each container. As a result, groups were different in each container and some tests were running twice (and probably some tests were not running at all).
Forcing sorting the files by name solves the issue. 