### PR TITLE
Follow links when splitting test files

### DIFF
--- a/src/SplitTestsByGroups.php
+++ b/src/SplitTestsByGroups.php
@@ -129,6 +129,7 @@ class SplitTestFilesByGroupsTask extends TestsSplitter implements TaskInterface
     public function run()
     {
         $files = Finder::create()
+            ->followLinks()
             ->name('*Cept.php')
             ->name('*Cest.php')
             ->name('*Test.php')


### PR DESCRIPTION
This seems appropriate to me since it matches the default codeception behaviour.  This was motivated because I was surprised that tests were missing after splitting when codeception would have included them.