### PR TITLE
Group loader fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,21 +42,39 @@ So we prepared a set of predefined Robo tasks that can be combined and reconfigu
 Load tests from a folder and distributes them between groups.
 
 ```php
-$this->taskSplitTestsByGroups(5)
+$result = $this->taskSplitTestsByGroups(5)
     ->testsFrom('tests/acceptance')
     ->projectRoot('.')
     ->groupsTo('tests/_data/group_')
     ->run();
+
+// task returns a result which contains information about processed data:
+// optionally check result data   
+if ($result->wasSuccessful()) {
+    $groups = $result['groups'];
+    $tests = $result['tests'];
+    $filenames = $result['files'];
+}
 ```
 
-this command uses `Codeception\Test\Loader` to load tests and organize them between group. If you want just split test file and not actual tests (and not load tests into memory) you can use:
+> This command **loads Codeception into memory**, loads and parses tests to organize them between group. If you want just split test file and not actual tests (and not load tests into memory) use `taskSplitTestFilesByGroups`:
+
+### SplitTestFilesByGroups
+
+To split tests by suites (files) without loading them into memory use `taskSplitTestFilesByGroups` method:
 
 ```php
-$this->taskSplitTestFilesByGroups(5)
+$result = $this->taskSplitTestFilesByGroups(5)
    ->testsFrom('tests')
    ->groupsTo('tests/_data/paratest_')
    ->run();
+
+// optionally check result data
+if ($result->wasSuccessful()) {
+    $filenames = $result['files'];
+}   
 ```
+
 ### SplitTestsByTime
 
 Enable extension for collect execution time of you use taskSplitTestsByTime
@@ -70,11 +88,16 @@ extensions:
 Load tests from a folder and distributes them between groups by execution time.
 
 ```php
-$this->taskSplitTestsByTime(5)
+$result = $this->taskSplitTestsByTime(5)
     ->testsFrom('tests/acceptance')
     ->projectRoot('.')
     ->groupsTo('tests/_data/group_')
     ->run();
+
+// optionally check result data
+if ($result->wasSuccessful()) {
+    $filenames = $result['files'];
+}
 ```
 
 this command need run all tests with `Codeception\Task\TimeReporter` for collect execution time. If you want just split tests between group (and not execute its) you can use SplitTestsByGroups. **Please be aware**: This task will not consider any 'depends' annotation!
@@ -100,11 +123,16 @@ $this->taskMergeFailedTestsReports()
 
 Load the failed Tests from a reportfile into the groups:
 ```php
-$this
+$result = $this
     ->taskSplitFailedTests(5)
     ->setReportPath(\Codeception\Configuration::outputDir() . 'failedTests.txt') // absoulute Path to Reportfile
     ->groupsTo(\Codeception\Configuration::outputDir() . 'group_')
     ->run();
+
+// optionally check result data
+if ($result->wasSuccessful()) {
+    $filenames = $result['files'];
+} 
 ```
 
 ### MergeXmlReports

--- a/src/Filter/GroupFilter.php
+++ b/src/Filter/GroupFilter.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Codeception\Task\Filter;
 
+use Codeception\Lib\GroupManager;
 use Codeception\Test\Descriptor as TestDescriptor;
 use Codeception\Util\Annotation;
 use InvalidArgumentException;
@@ -123,6 +124,8 @@ class GroupFilter implements Filter
      */
     public function filter(): array
     {
+        $groupManager = new GroupManager([]);
+
         $testsByGroups = [];
         foreach ($this->getTests() as $test) {
             if (!($test instanceof SelfDescribing)) {
@@ -130,17 +133,18 @@ class GroupFilter implements Filter
                     'Tests must be an instance of ' . SelfDescribing::class
                 );
             }
-            [$class, $method] = explode(':', TestDescriptor::getTestSignature($test));
-            $annotations = Annotation::forMethod($class, $method)->fetchAll('group');
+
+            $groups = $groupManager->groupsForTest($test);
+
             if (
                 !empty($this->getExcludedGroups())
-                && [] === array_diff($this->getExcludedGroups(), $annotations)
+                && [] === array_diff($this->getExcludedGroups(), $groups)
             ) {
                 continue;
             }
             if (
                 !empty($this->getIncludedGroups())
-                && [] !== array_diff($this->getIncludedGroups(), $annotations)
+                && [] !== array_diff($this->getIncludedGroups(), $groups)
             ) {
                 continue;
             }

--- a/src/Splitter/FailedTestSplitterTask.php
+++ b/src/Splitter/FailedTestSplitterTask.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Codeception\Task\Splitter;
 
 use InvalidArgumentException;
+use Robo\Result;
 use RuntimeException;
 
 class FailedTestSplitterTask extends TestsSplitter
@@ -23,7 +24,7 @@ class FailedTestSplitterTask extends TestsSplitter
     /**
      * @inheritDoc
      */
-    public function run()
+    public function run(): Result
     {
         $this->claimCodeceptionLoaded();
         $reportPath = $this->getReportPath();
@@ -34,7 +35,7 @@ class FailedTestSplitterTask extends TestsSplitter
             );
         }
 
-        $this->splitToGroupFiles(
+        $filenames = $this->splitToGroupFiles(
             $this->filter(
                 explode(
                     PHP_EOL,
@@ -42,6 +43,12 @@ class FailedTestSplitterTask extends TestsSplitter
                 )
             )
         );
+
+        $numFiles = count($filenames);
+
+        return Result::success($this, "Split all tests into $numFiles group files", [
+            'files' => $filenames,
+        ]);
     }
 
     /**

--- a/src/Splitter/SplitTestsByTimeTask.php
+++ b/src/Splitter/SplitTestsByTimeTask.php
@@ -8,6 +8,7 @@ use Codeception\Test\Loader;
 use JsonException;
 use PHPUnit\Framework\DataProviderTestSuite;
 use Robo\Exception\TaskException;
+use Robo\Result;
 use RuntimeException;
 
 /**
@@ -25,7 +26,7 @@ class SplitTestsByTimeTask extends TestsSplitter
         return $this;
     }
 
-    public function run(): void
+    public function run(): Result
     {
         $this->claimCodeceptionLoaded();
 
@@ -70,6 +71,7 @@ class SplitTestsByTimeTask extends TestsSplitter
             $groups[$i]['sum'] += $time;
         }
 
+        $filenames = [];
         // saving group files
         foreach ($groups as $i => ['tests' => $tests, 'sum' => $sum]) {
             $filename = $this->saveTo . ($i + 1);
@@ -82,7 +84,14 @@ class SplitTestsByTimeTask extends TestsSplitter
                 )
             );
             file_put_contents($filename, implode("\n", $tests));
+            $filenames[] = $filename;
         }
+
+        $numFiles = count($filenames);
+
+        return Result::success($this, "Split all tests into $numFiles group files", [
+            'files' => $filenames,
+        ]);
     }
 
     /**

--- a/src/Splitter/TestFileSplitterTask.php
+++ b/src/Splitter/TestFileSplitterTask.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Codeception\Task\Splitter;
 
+use Robo\Result;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Finder\SplFileInfo;
 
@@ -29,7 +30,7 @@ class TestFileSplitterTask extends TestsSplitter
 {
     private $pattern = ['*Cept.php', '*Cest.php', '*Test.php', '*.feature'];
 
-    public function run()
+    public function run(): Result
     {
         $files = Finder::create()
             ->followLinks()
@@ -38,7 +39,9 @@ class TestFileSplitterTask extends TestsSplitter
             ->in($this->projectRoot ?: getcwd())
             ->exclude($this->excludePath);
 
-        $this->splitToGroupFiles(
+
+
+        $filenames = $this->splitToGroupFiles(
             array_map(
                 static function (SplFileInfo $fileInfo): string {
                     return $fileInfo->getRelativePathname();
@@ -46,6 +49,12 @@ class TestFileSplitterTask extends TestsSplitter
                 $this->filter(iterator_to_array($files->getIterator()))
             )
         );
+
+        $numFiles = count($filenames);
+
+        return Result::success($this, "Split all tests into $numFiles group files", [
+            'files' => $filenames,
+        ]);
     }
 
     /**

--- a/src/Splitter/TestsSplitter.php
+++ b/src/Splitter/TestsSplitter.php
@@ -208,6 +208,8 @@ abstract class TestsSplitter extends BaseTask
                 'This task requires Codeception to be loaded. Please require autoload.php of Codeception'
             );
         }
+        // autoload PHPUnit files
+        \Codeception\PHPUnit\Init::init();
     }
 
     /**

--- a/src/Splitter/TestsSplitter.php
+++ b/src/Splitter/TestsSplitter.php
@@ -233,7 +233,7 @@ abstract class TestsSplitter extends BaseTask
 
         if (!Configuration::projectDir()) {
             $this->output()->writeln("Codeception config was not loaded, paths to tests may not be set correctly.");
-            $this->output()->writeln("Execute \Codeception\Configuration::config() before this task set root directory");
+            $this->output()->writeln("Execute \Codeception\Configuration::config() before this task");
         }
 
 

--- a/src/Splitter/TestsSplitter.php
+++ b/src/Splitter/TestsSplitter.php
@@ -225,7 +225,7 @@ abstract class TestsSplitter extends BaseTask
      * @param string[] $files - the relative path of the Testfile with or without test function
      * @example $this->splitToGroupFiles(['tests/FooCest.php', 'tests/BarTest.php:testBarReturn']);
      */
-    protected function splitToGroupFiles(array $files): void
+    protected function splitToGroupFiles(array $files): array
     {
         $i = 0;
         $groups = [];
@@ -239,11 +239,14 @@ abstract class TestsSplitter extends BaseTask
             $i++;
         }
 
+        $filenames = [];
         // saving group files
         foreach ($groups as $i => $tests) {
             $filename = $this->saveTo . $i;
             $this->printTaskInfo("Writing $filename");
             file_put_contents($filename, implode("\n", $tests));
+            $filenames[] = $filename;
         }
+        return $filenames;
     }
 }

--- a/src/Splitter/TestsSplitter.php
+++ b/src/Splitter/TestsSplitter.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Codeception\Task\Splitter;
 
+use Codeception\Configuration;
 use Codeception\Task\Filter\DefaultFilter;
 use Codeception\Task\Filter\Filter;
 use ReflectionClass;
@@ -229,6 +230,12 @@ abstract class TestsSplitter extends BaseTask
     {
         $i = 0;
         $groups = [];
+
+        if (!Configuration::projectDir()) {
+            $this->output()->writeln("Codeception config was not loaded, paths to tests may not be set correctly.");
+            $this->output()->writeln("Execute \Codeception\Configuration::config() before this task set root directory");
+        }
+
 
         $this->printTaskInfo('Processing ' . count($files) . ' files');
 

--- a/src/Splitter/TestsSplitterTask.php
+++ b/src/Splitter/TestsSplitterTask.php
@@ -33,10 +33,9 @@ class TestsSplitterTask extends TestsSplitter
 {
 
     /**
-     * @return bool|null
      * @throws \Robo\Exception\TaskException
      */
-    public function run()
+    public function run(): Result
     {
         $this->claimCodeceptionLoaded();
         $tests = $this->filter($this->loadTests());
@@ -100,7 +99,7 @@ class TestsSplitterTask extends TestsSplitter
                 );
             } catch (Exception $e) {
                 $this->printTaskError($e->getMessage());
-                return false;
+                return Result::error($this, $e->getMessage(), ['exception' => $e]);
             }
             // resolved and ordered list of dependencies
             $orderedListOfTests = [];
@@ -118,7 +117,7 @@ class TestsSplitterTask extends TestsSplitter
                     );
                 } catch (Exception $e) {
                     $this->printTaskError($e->getMessage());
-                    return false;
+                    return Result::error($this, $e->getMessage(), ['exception' => $e]);
                 }
             }
             // if we don't have any dependencies just use keys from original list.
@@ -157,7 +156,7 @@ class TestsSplitterTask extends TestsSplitter
         }
         $numFiles = count($filenames);
 
-        return Result::success($this, "Split $numTests into $numFiles", [
+        return Result::success($this, "Split $numTests into $numFiles group files", [
             'groups' => $groups,
             'tests' => $tests,
             'files' => $filenames,

--- a/src/Splitter/TestsSplitterTask.php
+++ b/src/Splitter/TestsSplitterTask.php
@@ -12,6 +12,7 @@ use Exception;
 use PHPUnit\Framework\DataProviderTestSuite;
 use PHPUnit\Framework\TestCase;
 use ReflectionObject;
+use Robo\Result;
 
 /**
  * Loads all tests into groups and saves them to groupfile according to pattern.
@@ -39,7 +40,8 @@ class TestsSplitterTask extends TestsSplitter
     {
         $this->claimCodeceptionLoaded();
         $tests = $this->filter($this->loadTests());
-        $this->printTaskInfo('Processing ' . count($tests) . ' tests');
+        $numTests = count($tests);
+        $this->printTaskInfo("Processing $numTests tests");
 
         $testsHaveAtLeastOneDependency = false;
 
@@ -145,14 +147,21 @@ class TestsSplitterTask extends TestsSplitter
             $groups[$i][] = $test;
         }
 
+        $filenames = [];
         // saving group files
-        foreach ($groups as $i => $tests) {
+        foreach ($groups as $i => $groupTests) {
             $filename = $this->saveTo . $i;
             $this->printTaskInfo("Writing $filename");
-            file_put_contents($filename, implode("\n", $tests));
+            file_put_contents($filename, implode("\n", $groupTests));
+            $filenames[] = $filename;
         }
+        $numFiles = count($filenames);
 
-        return null;
+        return Result::success($this, "Split $numTests into $numFiles", [
+            'groups' => $groups,
+            'tests' => $tests,
+            'files' => $filenames,
+        ]);
     }
 
     /**

--- a/tests/Splitter/TestsSplitterTaskTest.php
+++ b/tests/Splitter/TestsSplitterTaskTest.php
@@ -86,7 +86,14 @@ class TestsSplitterTaskTest extends TestCase
         $task->testsFrom($from);
         $groupTo = TEST_PATH . '/result/group_';
         $task->groupsTo($groupTo);
-        $task->run();
+        $result = $task->run();
+
+        $this->assertNotEmpty($result);
+
+        if ($expectedFiles > 0) {
+            $this->assertTrue($result->wasSuccessful());
+            $this->assertEquals($expectedFiles, count($result['files']));
+        }
 
         $files = Finder::create()
             ->files()


### PR DESCRIPTION
* All split* tasks to return results to use data in next commands
* Fixed splitGroup tasks to load Codeception and its PHPUnit shim
* Fixed splitGroup to load tests via GroupManager