### PR TITLE
bug/103 - Fix bug where leading character of a relative test name was…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [2.0.1](https://github.com/Codeception/robo-paracept/releases/tag/2.0.1) Bugfix Release - TimeReporter and FailedTestsReporter
+
+* Fix bug where leading character was being removed from tests in the reporter instead of leading directory separator
+
 ## [2.0.0](https://github.com/Codeception/robo-paracept/releases/tag/2.0.0) Major Release
 
 robo-paracept 2.0 is now released

--- a/src/Extension/FailedTestsReporter.php
+++ b/src/Extension/FailedTestsReporter.php
@@ -65,7 +65,8 @@ class FailedTestsReporter extends Extension
     {
         $name = Descriptor::getTestFullName($e->getTest());
 
-        return substr(str_replace($this->getRootDir(), '', $name), 1);
+        // If a leading DIRECTORY_SEPARATOR was found, remove it
+        return ltrim(str_replace($this->getRootDir(), '', $name), DIRECTORY_SEPARATOR);
     }
 
     public function getUniqReportFile(): string

--- a/src/Extension/TimeReporter.php
+++ b/src/Extension/TimeReporter.php
@@ -45,6 +45,8 @@ class TimeReporter extends Extension
     public function getTestName(TestEvent $e): string
     {
         $name = Descriptor::getTestFullName($e->getTest());
-        return substr(str_replace($this->getRootDir(), '', $name), 1);
+
+        // If a leading DIRECTORY_SEPARATOR was found, remove it
+        return ltrim(str_replace($this->getRootDir(), '', $name), DIRECTORY_SEPARATOR);
     }
 }


### PR DESCRIPTION
… being removed erroneously

Resolves #103. I tried to unit test this, but the test reporters would both require some reasonable refactoring to remove their hard dependencies on Codeception global functions, so I opted for just the working change.