### PR TITLE
Adding the symfony 6 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     },
     "require": {
         "php": "^7.4 | ^8.0",
-        "consolidation/robo": "3.0.*",
+        "consolidation/robo": "3.0.* | 4.0.*",
         "symfony/finder": ">=2.7",
         "ext-dom": "*",
         "ext-libxml": "*",

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "require": {
         "php": "^7.4 | ^8.0",
         "consolidation/robo": "3.0.*",
-        "symfony/finder": ">=2.7 <6.0",
+        "symfony/finder": ">=2.7",
         "ext-dom": "*",
         "ext-libxml": "*",
         "ext-json": "*"


### PR DESCRIPTION
Codeception 5 now support Symfony 6.

Using robo-paracept with Symfony 6 is leading to:
```codeception/robo-paracept 2.0.0 requires symfony/finder >=2.7 <6.0 -> found symfony/finder[v2.7.0, ..., v2.8.52, v3.0.0, ..., v3.4.47, v4.0.0, ..., v4.4.44, v5.0.0, ..., v5.4.11] but the package is fixed to v6.0.11 (lock file version) by a partial update and that version does not match. Make sure you list it as an argument for the update command.```

during the `composer install`.

I'm trying to make the robo-paracept library compatible with Symfony 6.